### PR TITLE
allow mixing .env and variables from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A webhook service that connects [Miniflux](https://miniflux.app/) (an RSS feed r
 
    - `HOARDER_API_TOKEN`: Generate this in Hoarder (Settings → API Keys)
    - `WEBHOOK_SECRET`: This will be generated when enabling webhooks in Miniflux (we'll get this in step 4)
+   - `HOARDER_API_URL`: URL of the Hoarder instance (e.g. http://web:3000)
    - `SAVE_NEW_ENTRIES`: Set to `true` to save all new entries (default: `false`)
 
 ### 3. Configure Docker Compose Files

--- a/main.go
+++ b/main.go
@@ -165,22 +165,22 @@ func GetBoolEnv(key string) (bool, error) {
 
 func loadConfig() error {
 	if err := godotenv.Load(); err != nil {
-		return fmt.Errorf("error loading .env file: %w", err)
+		fmt.Printf(".env file not loaded: %s\n", err)
 	}
 
 	webhookSecret = os.Getenv("WEBHOOK_SECRET")
 	if webhookSecret == "" {
-		return errors.New("WEBHOOK_SECRET must be set in .env file")
+		return errors.New("WEBHOOK_SECRET must be set in .env file or environment")
 	}
 
 	bookmarkAPI = os.Getenv("HOARDER_API_URL")
 	if bookmarkAPI == "" {
-		return errors.New("HOARDER_API_URL must be set in .env file")
+		return errors.New("HOARDER_API_URL must be set in .env file or environment")
 	}
 
 	apiToken = os.Getenv("HOARDER_API_TOKEN")
 	if apiToken == "" {
-		return errors.New("HOARDER_API_TOKEN must be set in .env file")
+		return errors.New("HOARDER_API_TOKEN must be set in .env file or environment")
 	}
 
 	var err error


### PR DESCRIPTION
I wanted to be able to set environment variables directly rather than using a `.env` file as part of a [NixOS module](https://github.com/devusb/nix-packages/blob/main/modules/nixos/hoarder-miniflux-webhook.nix); this change still allows a `.env` file to work, but does not fail if the file does not exist as long as the required variables are set in the environment.

I also added a mention of `HOARDER_API_URL` to the `README`, as it seemed required but was not listed.